### PR TITLE
Make sure the file is closed upon exit.

### DIFF
--- a/fit.go
+++ b/fit.go
@@ -282,7 +282,8 @@ func Parse(filename string, show_verbose_mode bool) FitFile {
 
 	r, err := os.Open(filename)
 	check(err)
-
+	defer r.Close()
+	
 	//test to read first record header
 	rHead := make([]byte, 1)
 


### PR DESCRIPTION
I'm getting a file not closed message when I attempt to delete the fit file whose name I pass into fit.Parse.  It doesn't appear to me that Parse closes the file after looping through the bytes.  This one-liner will close  on exiting fit.Parse allowing me to delete.  In any event, it's just a good practice.